### PR TITLE
Workaround Jekyll 3.8.1 bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:latest
+FROM jekyll/jekyll:3.8.0
 
 COPY Gemfile* /srv/jekyll/
 


### PR DESCRIPTION
Problem with `bundler` installation:

```
/usr/local/lib/ruby/site_ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundler (Gem::GemNotFoundException)
	from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
	from /usr/local/bin/bundler:23:in `<main>'
```